### PR TITLE
Add endpoint to get all categories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,77 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+#INtelij
+*.idea
+*.DS_Store
+*.iml

--- a/src/main/java/com/fcgl/madrid/dev/IndexController.java
+++ b/src/main/java/com/fcgl/madrid/dev/IndexController.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.Date;
 
 @Controller
-@RequestMapping("/")
+@RequestMapping("/dev")
 public class IndexController {
     private final Logger logger = Logger.getLogger(this.getClass().getName());
 

--- a/src/main/java/com/fcgl/madrid/search/controller/CategoryController.java
+++ b/src/main/java/com/fcgl/madrid/search/controller/CategoryController.java
@@ -1,0 +1,28 @@
+package com.fcgl.madrid.search.controller;
+import com.fcgl.madrid.search.dataModel.Category;
+import com.fcgl.madrid.search.payload.response.Response;
+import com.fcgl.madrid.search.util.CategoryService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@RestController
+@RequestMapping("/search/category/v1")
+public class CategoryController {
+    private CategoryService categoryService;
+
+    @Autowired
+    public void setServices(CategoryService categoryService) {
+        this.categoryService = categoryService;
+    }
+
+    @GetMapping(path = "/allCategories")
+    public ResponseEntity<Response<List<Category>>> getAllCategories() {
+        return categoryService.getAllCategories();
+    }
+}
+
+

--- a/src/main/java/com/fcgl/madrid/search/payload/InternalStatus.java
+++ b/src/main/java/com/fcgl/madrid/search/payload/InternalStatus.java
@@ -1,0 +1,78 @@
+package com.fcgl.madrid.search.payload;
+
+
+import org.springframework.http.HttpStatus;
+import java.util.List;
+import java.util.ArrayList;
+
+public class InternalStatus {
+    public static final InternalStatus OK = new InternalStatus(StatusCode.OK, HttpStatus.OK, "ok");
+    public static final InternalStatus MISSING_PARAM = new InternalStatus(StatusCode.PARAM, HttpStatus.BAD_REQUEST, "Missing Required Param");
+    public static final InternalStatus NOT_FOUND = new InternalStatus(StatusCode.NOT_FOUND, HttpStatus.NOT_FOUND, "Data Not Found");
+
+    private int code;
+    private HttpStatus httpCode;
+    private List<String> messages;
+
+    public InternalStatus() {
+
+    }
+
+    public InternalStatus(StatusCode statusCode, HttpStatus httpCode, String message) {
+        this.code = statusCode.getCode();
+        this.httpCode = httpCode;
+        this.messages = new ArrayList<String>();
+        this.messages.add(message);
+    }
+
+    public InternalStatus(StatusCode statusCode, HttpStatus httpCode, List<String> messages) {
+        this.code = statusCode.getCode();
+        this.httpCode = httpCode;
+        this.messages = messages;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public void setCode(int code) {
+        this.code = code;
+    }
+
+    public HttpStatus getHttpCode() {
+        return httpCode;
+    }
+
+    public void setHttpCode(HttpStatus httpCode) {
+        this.httpCode = httpCode;
+    }
+
+    public List<String> getMessages() {
+        return messages;
+    }
+
+    public void setMessages(List<String> messages) {
+        this.messages = messages;
+    }
+
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        if (!super.equals(object)) return false;
+
+        InternalStatus that = (InternalStatus) object;
+
+        if (code != that.code) return false;
+        if (httpCode != that.httpCode) return false;
+        return messages != null ? messages.equals(that.messages) : that.messages == null;
+    }
+
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + code;
+        result = 31 * result + (httpCode != null ? httpCode.hashCode() : 0);
+        result = 31 * result + (messages != null ? messages.hashCode() : 0);
+        return result;
+    }
+}
+

--- a/src/main/java/com/fcgl/madrid/search/payload/StatusCode.java
+++ b/src/main/java/com/fcgl/madrid/search/payload/StatusCode.java
@@ -1,0 +1,21 @@
+package com.fcgl.madrid.search.payload;
+
+public class StatusCode {
+    public static final StatusCode UNKNOWN = new StatusCode(-1);
+    public static final StatusCode OK = new StatusCode(1);
+    public static final StatusCode PARAM = new StatusCode(2);
+    public static final StatusCode NOT_FOUND = new StatusCode(3);
+    public static final StatusCode AUTH_ERROR = new StatusCode(4);
+
+    private int code;
+
+    StatusCode(int code) {
+        this.code = code;
+    }
+
+
+    public int getCode() {
+        return code;
+    }
+
+}

--- a/src/main/java/com/fcgl/madrid/search/payload/request/SearchRequest.java
+++ b/src/main/java/com/fcgl/madrid/search/payload/request/SearchRequest.java
@@ -1,0 +1,29 @@
+package com.fcgl.madrid.search.payload.request;
+import javax.validation.constraints.NotNull;
+
+public class SearchRequest {
+    private Long userId;
+    @NotNull
+    private String query;
+
+    public SearchRequest(Long userId, String query) {
+        this.userId = userId;
+        this.query = query;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/search/payload/response/Response.java
+++ b/src/main/java/com/fcgl/madrid/search/payload/response/Response.java
@@ -1,0 +1,40 @@
+package com.fcgl.madrid.search.payload.response;
+import com.fcgl.madrid.search.payload.InternalStatus;
+
+import java.time.Instant;
+
+public class Response<T> {
+    private T response;
+    private InternalStatus status;
+    private Long timestamp;
+
+    public Response(InternalStatus status, T response) {
+        this.status = status;
+        this.response = response;
+        this.timestamp = Instant.now().toEpochMilli();
+    }
+
+    public T getResponse() {
+        return response;
+    }
+
+    public void setResponse(T response) {
+        this.response = response;
+    }
+
+    public InternalStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(InternalStatus status) {
+        this.status = status;
+    }
+
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Long timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/search/util/CategoryService.java
+++ b/src/main/java/com/fcgl/madrid/search/util/CategoryService.java
@@ -4,22 +4,13 @@ import com.fcgl.madrid.search.dataModel.Category;
 import com.fcgl.madrid.search.payload.InternalStatus;
 import com.fcgl.madrid.search.payload.response.Response;
 import com.fcgl.madrid.search.repository.CategoryRepository;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.TransactionSystemException;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 @Service
 public class CategoryService {

--- a/src/main/java/com/fcgl/madrid/search/util/CategoryService.java
+++ b/src/main/java/com/fcgl/madrid/search/util/CategoryService.java
@@ -1,0 +1,39 @@
+package com.fcgl.madrid.search.util;
+
+import com.fcgl.madrid.search.dataModel.Category;
+import com.fcgl.madrid.search.payload.InternalStatus;
+import com.fcgl.madrid.search.payload.response.Response;
+import com.fcgl.madrid.search.repository.CategoryRepository;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.TransactionSystemException;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Service
+public class CategoryService {
+
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    public CategoryService(CategoryRepository categoryRepository) {
+        this.categoryRepository = categoryRepository;
+    }
+
+    public ResponseEntity<Response<List<Category>>> getAllCategories() {
+        List<Category> allCategories = categoryRepository.findAll();
+        Response response = new Response<>(InternalStatus.OK, allCategories);
+        return new ResponseEntity<Response<List<Category>>>(response, HttpStatus.OK);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-spring.data.mongodb.host=hk-mongodb
+spring.data.mongodb.host=search-mongodb


### PR DESCRIPTION
## Problem

Native app needs to know what categories we have to help with user search

## Solution

Add endpoint that returns the categories

## Testing
1. Make an api call to http://localhost:8084/dev/test in order to populate your database
2. Make the following api request: http://localhost:8084/search/category/v1/allCategories
    * Confirm that you get the following response:
```
{
    "response": [
        {
            "id": 1,
            "categoryName": "Beverages",
            "description": "drinks",
            "addedOn": "2019-10-08T12:30:24.729+0000",
            "lastUpdated": "2019-10-08T12:30:24.729+0000"
        },
        {
            "id": 2,
            "categoryName": "Dessert",
            "description": "sweet food",
            "addedOn": "2019-10-08T12:30:24.751+0000",
            "lastUpdated": "2019-10-08T12:30:24.751+0000"
        }
    ],
    "status": {
        "code": 1,
        "httpCode": "OK",
        "messages": [
            "ok"
        ]
    },
    "timestamp": 1570560887203
}
```