### PR TITLE
Endpoint Skeleton

### DIFF
--- a/src/main/java/com/fcgl/madrid/search/controller/CategoryController.java
+++ b/src/main/java/com/fcgl/madrid/search/controller/CategoryController.java
@@ -40,7 +40,7 @@ public class CategoryController {
      *
      */
     @GetMapping(path="/search")
-    public ResponseEntity<Response<List<Product>>> GetCategoryProducts(CategorySearchRequest request) {
+    public ResponseEntity<Response<List<Product>>> GetCategoryProducts(@Valid CategorySearchRequest request) {
         return null;
     }
 }

--- a/src/main/java/com/fcgl/madrid/search/controller/CategoryController.java
+++ b/src/main/java/com/fcgl/madrid/search/controller/CategoryController.java
@@ -1,7 +1,9 @@
 package com.fcgl.madrid.search.controller;
 import com.fcgl.madrid.search.dataModel.Category;
+import com.fcgl.madrid.search.dataModel.Product;
+import com.fcgl.madrid.search.payload.request.CategorySearchRequest;
 import com.fcgl.madrid.search.payload.response.Response;
-import com.fcgl.madrid.search.util.CategoryService;
+import com.fcgl.madrid.search.service.CategoryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,6 +25,22 @@ public class CategoryController {
     public ResponseEntity<Response<List<Category>>> getAllCategories() {
         return categoryService.getAllCategories();
     }
+
+
+    /**
+     * Searches based on category
+     *  TODO: Return a paginated list of products based on the categoryId sent in the request...
+     *        Note: Should return a ResponseEntity<Response<List<?>> The ? could be another object if necessary
+     *        OR: List<?> could also be a Object with a List<?> as one of it's fields
+     *        RESPONSE: Product Name, Category Name(s), Retail Price, Merchant Price, Merchant Location, Product Image,
+     *            Along with IDs for whatever Ids that might be helpful (Product/MerchantProduct Id)
+     *
+     * Extra TODO: We would want to return a result sorted based on distance from the user. Have not looked into how
+     *              geolocation works yet. But would be an extra once we figure that out
+     *
+     */
+    @GetMapping(path="/search")
+    public ResponseEntity<Response<List<Product>>> GetCategoryProducts(CategorySearchRequest request) {
+        return null;
+    }
 }
-
-

--- a/src/main/java/com/fcgl/madrid/search/controller/ProductController.java
+++ b/src/main/java/com/fcgl/madrid/search/controller/ProductController.java
@@ -31,7 +31,7 @@ public class ProductController {
      * about security in this endpoint as it will be taken care of
      */
     @PostMapping(path = "/productPopularityIndex")
-    public ResponseEntity<Response<InternalStatus>> updatePopularityIndex(@RequestBody List<ProductBody> request) {
+    public ResponseEntity<Response<InternalStatus>> updatePopularityIndex(@Valid @RequestBody List<ProductBody> request) {
         return null;
     }
 }

--- a/src/main/java/com/fcgl/madrid/search/controller/ProductController.java
+++ b/src/main/java/com/fcgl/madrid/search/controller/ProductController.java
@@ -1,0 +1,37 @@
+package com.fcgl.madrid.search.controller;
+import com.fcgl.madrid.search.dataModel.Category;
+import com.fcgl.madrid.search.dataModel.Product;
+import com.fcgl.madrid.search.payload.InternalStatus;
+import com.fcgl.madrid.search.payload.request.CategorySearchRequest;
+import com.fcgl.madrid.search.payload.request.ProductBody;
+import com.fcgl.madrid.search.payload.response.Response;
+import com.fcgl.madrid.search.service.CategoryService;
+import com.fcgl.madrid.search.service.ProductService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@RestController
+@RequestMapping("/search/product/v1")
+public class ProductController {
+    private ProductService productService;
+
+    @Autowired
+    public void setServices(ProductService productService) {
+        this.productService = productService;
+    }
+
+    /**
+     * TODO: Update the popularityIndex
+     * Parses the List<ProductBody> and updates every Product based on the id and the new popularityIndex
+     * Note: We will be securing our API through JWT tokens which include encrypted Roles. So do need to worry
+     * about security in this endpoint as it will be taken care of
+     */
+    @PostMapping(path = "/productPopularityIndex")
+    public ResponseEntity<Response<InternalStatus>> updatePopularityIndex(@RequestBody List<ProductBody> request) {
+        return null;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/search/controller/UserSearchController.java
+++ b/src/main/java/com/fcgl/madrid/search/controller/UserSearchController.java
@@ -31,7 +31,7 @@ public class UserSearchController {
      * TODO: Based on what we find out on elastic search. We might have to make an api request to elastic search from here as well.
      */
     @GetMapping(path = "/query")
-    public ResponseEntity<Response> addUserSearchQuery(UserSearchRequest request) {
+    public ResponseEntity<Response> addUserSearchQuery(@Valid UserSearchRequest request) {
         //Call a function is userSearchService
         return null;
     }

--- a/src/main/java/com/fcgl/madrid/search/controller/UserSearchController.java
+++ b/src/main/java/com/fcgl/madrid/search/controller/UserSearchController.java
@@ -1,0 +1,38 @@
+package com.fcgl.madrid.search.controller;
+
+import com.fcgl.madrid.search.dataModel.Category;
+import com.fcgl.madrid.search.dataModel.Product;
+import com.fcgl.madrid.search.payload.request.CategorySearchRequest;
+import com.fcgl.madrid.search.payload.request.UserSearchRequest;
+import com.fcgl.madrid.search.payload.response.Response;
+import com.fcgl.madrid.search.service.CategoryService;
+import com.fcgl.madrid.search.service.UserSearchService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@RestController
+@RequestMapping("/search/userSearch/v1")
+public class UserSearchController {
+    private UserSearchService userSearchService;
+
+    @Autowired
+    public void setServices(UserSearchService categoryService) {
+        this.userSearchService = categoryService;
+    }
+
+    /**
+     * We want to keep track of the searches a user has made
+     * This endpoint simply adds an entry to the UserSearch database table based on the search a user has made
+     *
+     * TODO: Based on what we find out on elastic search. We might have to make an api request to elastic search from here as well.
+     */
+    @GetMapping(path = "/query")
+    public ResponseEntity<Response> addUserSearchQuery(UserSearchRequest request) {
+        //Call a function is userSearchService
+        return null;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/search/controller/exceptionHandler/CustomExceptionHandler.java
+++ b/src/main/java/com/fcgl/madrid/search/controller/exceptionHandler/CustomExceptionHandler.java
@@ -1,0 +1,70 @@
+package com.fcgl.madrid.search.controller.exceptionHandler;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fcgl.madrid.search.payload.InternalStatus;
+import com.fcgl.madrid.search.payload.StatusCode;
+import com.fcgl.madrid.search.payload.response.Response;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+
+@ControllerAdvice
+public class CustomExceptionHandler extends ResponseEntityExceptionHandler{
+
+
+    @Override
+    protected ResponseEntity<Object> handleBindException(
+            BindException ex,
+            HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request) {
+        return genericErrorHandler(ex, ex.getBindingResult(), headers, status, request);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request) {
+        return genericErrorHandler(ex, ex.getBindingResult(), headers, status, request);
+
+    }
+
+    private ResponseEntity<Object> genericErrorHandler(
+            Exception ex,
+            BindingResult bindingResult,
+            HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request) {
+        List<String> errors = new ArrayList<String>();
+        for (FieldError error : bindingResult.getFieldErrors()) {
+            errors.add(error.getField() + " " + error.getDefaultMessage());
+        }
+        for (ObjectError error : bindingResult.getGlobalErrors()) {
+            errors.add(error.getObjectName() + " " + error.getDefaultMessage());
+        }
+
+        InternalStatus internalStatus = new InternalStatus(StatusCode.PARAM, HttpStatus.BAD_REQUEST, errors);
+        Response loginResponse = new Response<>(internalStatus, null);
+        return handleExceptionInternal(
+                ex, loginResponse, headers, internalStatus.getHttpCode(), request);
+    }
+
+}
+

--- a/src/main/java/com/fcgl/madrid/search/dataModel/Product.java
+++ b/src/main/java/com/fcgl/madrid/search/dataModel/Product.java
@@ -4,7 +4,14 @@ import org.springframework.data.annotation.Id;
 import java.util.Date;
 import java.util.List;
 
-
+/**
+ * Should Product have a countryId?
+ *
+ * We should have some logic that updates the popularity index based on how many
+ * people add it to their shopping list. The shopping list is in a different service.
+ * So perhaps we will have the popularityIndex be calculated in the ShoppingList Service
+ * and then make an API request to update tha popularityIndex here...
+ */
 public class Product {
 
     @Id
@@ -16,6 +23,7 @@ public class Product {
     public int barcode;
     public String default_image;
     public List<String> categories;
+    public float popularityIndex;
 
     public Product() {}
 
@@ -29,6 +37,20 @@ public class Product {
 		this.barcode = barcode;
 		this.default_image = default_image;
 		this.categories = categories;
+		this.popularityIndex = 0;
+	}
+
+    public Product(int id, String name, Double retail_price, Date added_on, Date last_updated, int barcode,
+			String default_image, List<String> categories, float popularityIndex) {
+		this.id = id;
+		this.name = name;
+		this.retail_price = retail_price;
+		this.added_on = added_on;
+		this.last_updated = last_updated;
+		this.barcode = barcode;
+		this.default_image = default_image;
+		this.categories = categories;
+		this.popularityIndex = popularityIndex;
 	}
 
     @Override
@@ -42,6 +64,7 @@ public class Product {
                 ", barcode=" + barcode +
                 ", default_image='" + default_image + '\'' +
                 ", categories=" + categories +
+                ", popularityIndex=" + popularityIndex +
                 '}';
     }
 }

--- a/src/main/java/com/fcgl/madrid/search/dataModel/UserSearch.java
+++ b/src/main/java/com/fcgl/madrid/search/dataModel/UserSearch.java
@@ -1,0 +1,27 @@
+package com.fcgl.madrid.search.dataModel;
+import org.springframework.data.annotation.Id;
+import java.util.Date;
+
+public class UserSearch {
+
+    @Id
+    public int id;
+    public Integer userId;
+    public String query;
+    public Date addedOn;
+
+    public UserSearch(int id, String categoryName, String description, Date addedOn, Date lastUpdated) {
+        this.id = id;
+        this.addedOn = addedOn;
+    }
+
+    @Override
+    public String toString() {
+        return "UserSearch{" +
+                "id=" + id +
+                ", userId=" + userId +
+                ", query='" + query + '\'' +
+                ", addedOn=" + addedOn +
+                '}';
+    }
+}

--- a/src/main/java/com/fcgl/madrid/search/payload/request/CategorySearchRequest.java
+++ b/src/main/java/com/fcgl/madrid/search/payload/request/CategorySearchRequest.java
@@ -1,0 +1,53 @@
+package com.fcgl.madrid.search.payload.request;
+
+import javax.validation.constraints.NotNull;
+
+public class CategorySearchRequest {
+    @NotNull
+    private Integer categoryId;
+    //Page and Size are for pagination reasons
+    @NotNull
+    private Integer page;
+    @NotNull
+    private Integer size;
+
+    //We will only be supporting Madrid at the beginning, but we should still
+    //work based on the cityId. Currently none of our database models take cityId into account
+    //Will probably have to be added to one or all of the Merchant Data Models
+    private Integer cityid;
+
+    CategorySearchRequest(Integer categoryId, Integer cityid, Integer page, Integer size) {
+        this.categoryId = categoryId;
+        this.cityid = cityid;
+        this.page = page;
+        this.size = size;
+    }
+
+    public Integer getCategoryId() {
+        return categoryId;
+    }
+
+    public Integer getPage() {
+        return page;
+    }
+
+    public void setPage(Integer page) {
+        this.page = page;
+    }
+
+    public Integer getSize() {
+        return size;
+    }
+
+    public void setSize(Integer size) {
+        this.size = size;
+    }
+
+    public Integer getCityid() {
+        return cityid;
+    }
+
+    public void setCityid(Integer cityid) {
+        this.cityid = cityid;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/search/payload/request/CategorySearchRequest.java
+++ b/src/main/java/com/fcgl/madrid/search/payload/request/CategorySearchRequest.java
@@ -16,7 +16,7 @@ public class CategorySearchRequest {
     //Will probably have to be added to one or all of the Merchant Data Models
     private Integer cityid;
 
-    CategorySearchRequest(Integer categoryId, Integer cityid, Integer page, Integer size) {
+    public CategorySearchRequest(Integer categoryId, Integer cityid, Integer page, Integer size) {
         this.categoryId = categoryId;
         this.cityid = cityid;
         this.page = page;

--- a/src/main/java/com/fcgl/madrid/search/payload/request/ProductBody.java
+++ b/src/main/java/com/fcgl/madrid/search/payload/request/ProductBody.java
@@ -1,0 +1,30 @@
+package com.fcgl.madrid.search.payload.request;
+import javax.validation.constraints.NotNull;
+
+public class ProductBody {
+    @NotNull
+    private Integer productId;
+    @NotNull
+    private Float popularityIndex;
+
+    public ProductBody(Integer productId, Float popularityIndex) {
+        this.productId = productId;
+        this.popularityIndex = popularityIndex;
+    }
+
+    public Integer getProductId() {
+        return productId;
+    }
+
+    public void setProductId(Integer productId) {
+        this.productId = productId;
+    }
+
+    public Float getPopularityIndex() {
+        return popularityIndex;
+    }
+
+    public void setPopularityIndex(Float popularityIndex) {
+        this.popularityIndex = popularityIndex;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/search/payload/request/UserSearchRequest.java
+++ b/src/main/java/com/fcgl/madrid/search/payload/request/UserSearchRequest.java
@@ -1,12 +1,12 @@
 package com.fcgl.madrid.search.payload.request;
 import javax.validation.constraints.NotNull;
 
-public class SearchRequest {
+public class UserSearchRequest {
     private Long userId;
     @NotNull
     private String query;
 
-    public SearchRequest(Long userId, String query) {
+    public UserSearchRequest(Long userId, String query) {
         this.userId = userId;
         this.query = query;
     }

--- a/src/main/java/com/fcgl/madrid/search/payload/request/UserSearchRequest.java
+++ b/src/main/java/com/fcgl/madrid/search/payload/request/UserSearchRequest.java
@@ -1,9 +1,11 @@
 package com.fcgl.madrid.search.payload.request;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotEmpty;
 
 public class UserSearchRequest {
-    private Long userId;
     @NotNull
+    private Long userId;
+    @NotEmpty
     private String query;
 
     public UserSearchRequest(Long userId, String query) {

--- a/src/main/java/com/fcgl/madrid/search/service/CategoryService.java
+++ b/src/main/java/com/fcgl/madrid/search/service/CategoryService.java
@@ -1,4 +1,4 @@
-package com.fcgl.madrid.search.util;
+package com.fcgl.madrid.search.service;
 
 import com.fcgl.madrid.search.dataModel.Category;
 import com.fcgl.madrid.search.payload.InternalStatus;

--- a/src/main/java/com/fcgl/madrid/search/service/ProductService.java
+++ b/src/main/java/com/fcgl/madrid/search/service/ProductService.java
@@ -1,0 +1,21 @@
+package com.fcgl.madrid.search.service;
+
+import com.fcgl.madrid.search.repository.ProductRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ProductService {
+
+    private ProductRepository productRepository;
+
+    @Autowired
+    public ProductService(ProductRepository productRepository) {
+        this.productRepository = productRepository;
+    }
+
+}

--- a/src/main/java/com/fcgl/madrid/search/service/UserSearchService.java
+++ b/src/main/java/com/fcgl/madrid/search/service/UserSearchService.java
@@ -1,0 +1,18 @@
+package com.fcgl.madrid.search.service;
+
+import com.fcgl.madrid.search.dataModel.Category;
+import com.fcgl.madrid.search.payload.InternalStatus;
+import com.fcgl.madrid.search.payload.response.Response;
+import com.fcgl.madrid.search.repository.CategoryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class UserSearchService {
+    //TODO: Add necessary functions
+}


### PR DESCRIPTION
## Problem

We will be using elastic search for a normal search, but there are some other endpoints this service needs to take into account

## Solution

Add endpoints with documentation ("Skeletons"). They currently only return null

**Endpoints:**
1. GET: `/search/category/v1/search`:
    * Searches based on category
2. POST: `/search/product/v1/productPopularityIndex`
    * Updates Product's popularityIndex
3. POST: `/search/userSearch/v1/query`
    * Insert a user's query into UserSearch

## Test
1. Run and build: `docker-compose up --build`
2. Confirm that you are able to make an API request to each endpoint (Won't return anything). Just confirm that there is no error. 