### PR TITLE
elastic search docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,8 @@ Elastic Search info endpoint: http://localhost:9200
 Elastic Search health endpoint: http://localhost:9200/_cat/health
 Kibana: http://localhost:5601
 
+**Note:** Might have to increase the memory in your Docker preferences in order to get Elastic Search, and as a result the app,
+to work. Works properly on 4.5GB of memory but could work on lower. 
+
 **Reference:** http://codingfundas.com/setting-up-elasticsearch-6-8-with-kibana-and-x-pack-security-enabled/index.html
 

--- a/README.md
+++ b/README.md
@@ -22,4 +22,11 @@ This build should work for both macOS and Linux
 
 Confirm everything was ran correctly by going to the following endpoint: 
   * http://localhost:8084/health/v1/marco
+  
+## Elastic Search
+Elastic Search info endpoint: http://localhost:9200
+Elastic Search health endpoint: http://localhost:9200/_cat/health
+Kibana: http://localhost:5601
+
+**Reference:** http://codingfundas.com/setting-up-elasticsearch-6-8-with-kibana-and-x-pack-security-enabled/index.html
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3"
 services:
   search:
     build:
@@ -20,3 +20,19 @@ services:
       - MONGO_LOG_DIR=/dev/null
       - MONGODB_USER="user"
       - MONGODB_USER="pass"
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.0
+    ports:
+      - 9200:9200
+    volumes:
+      - ./docker/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
+
+  kibana:
+    depends_on:
+      - elasticsearch
+    image: docker.elastic.co/kibana/kibana:6.8.0
+    ports:
+      - 5601:5601
+    volumes:
+      - ./docker/kibana.yml:/usr/share/kibana/config/kibana.yml
+

--- a/docker/elasticsearch.yml
+++ b/docker/elasticsearch.yml
@@ -1,0 +1,3 @@
+cluster.name: my-elasticsearch-cluster
+network.host: 0.0.0.0
+xpack.security.enabled: false

--- a/docker/kibana.yml
+++ b/docker/kibana.yml
@@ -1,0 +1,3 @@
+server.name: kibana
+server.host: "0"
+elasticsearch.hosts: [ "http://elasticsearch:9200" ]


### PR DESCRIPTION
## Problem

We need every developer to have elastic search on their machine when the app is ran

## Solution

Add images for elastic search and kibana

## Test
1. `docker-compose up --build`. If you get error code 137. You are going to want to increase the Memory in your Docker Preferences (I set mine to 4.5 gb)
2. Go to the following endpoints and confirm they respond successfully
    * Elastic Search info endpoint: http://localhost:9200
    * Elastic Search health endpoint: http://localhost:9200/_cat/health
    * Kibana: http://localhost:5601